### PR TITLE
changing dependency to recent version of casebase repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN . /etc/environment \
   # && sudo apt-get update \
   # && sudo apt-get install libudunits2-dev -y \
   # && Rscript -e 'options(error = function() traceback()) ; system("echo $NAMES") ; devtools::install_github(paste0(Sys.getenv(c("NAMES")), "/casebase"))' \
-  && Rscript -e 'options(error = function() traceback()) ; system("echo $NAMES") ; devtools::install_github(paste0("cssc2018", "/casebase"), dependencies = TRUE)' \
+  && Rscript -e 'options(error = function() traceback()) ; system("echo $NAMES") ; devtools::install_github(paste0("sahirbhatnagar", "/casebase"), dependencies = TRUE)' \
 
   # build this compendium package
   && R -e "devtools::install('/cbpaper', dep=TRUE)" \


### PR DESCRIPTION
for some reason, because `sahirbhatnagar` was getting masked by `[secure]`, so we could never install the github version of casebase. That's why `css2018/casebase` worked. For whatever reason, we're not having that issue anymore.