### PR TITLE
Fixed references

### DIFF
--- a/analysis/paper/casebase-manuscript.bib
+++ b/analysis/paper/casebase-manuscript.bib
@@ -333,9 +333,24 @@
 
 @misc{perperoglou, title={Package CoxRidge}, url={https://CRAN.R-project.org/package=CoxRidge}, journal={CRAN}, author={Perperoglou, Aris}, year={2015}, month={Feb}}
 
-@misc{fu, title={Package crrp}, url={https://cran.r-project.org/web/packages/crrp/index.html}, journal={CRAN}, author={Fu, Zhixuan},year={2015},month={Jun}}
+@Manual{fu,
+  title = {crrp: Penalized Variable Selection in Competing Risks Regression},
+  author = {Zhixuan Fu},
+  year = {2015},
+  note = {R package version 1.0},
+  url = {https://CRAN.R-project.org/package=crrp},
+}
 
-@misc{yi_zou, title={Package fastcox}, url={https://cran.r-project.org/web/packages/fastcox/index.html}, journal={CRAN}, author={Yi, Yang and Zou, Hui},year={2017},month={Sep}}
+
+@Manual{yi_zou,
+  title = {fastcox: Lasso and Elastic-Net Penalized Cox's Regression in High
+Dimensions Models using the Cocktail Algorithm},
+  author = {Yi Yang and Hui Zou},
+  year = {2017},
+  note = {R package version 1.1.3},
+  url = {https://CRAN.R-project.org/package=fastcox},
+}
+
 
 @Manual{flexrsurv, title = {{flexrsurv}: An {R} package for relative survival analysis}, author = {Isabelle Clerc-Urm\`{e}s and Michel Grzebyk and Guy H\'{e}delin}, year = {2017}, url = {https://CRAN.R-project.org/package=flexrsurv}, note = {R package version 1.4.1}, }
 
@@ -343,13 +358,42 @@
 
 @Article{regpathcox, title = {Regularization Paths for Cox's Proportional Hazards Model via Coordinate Descent}, author = {Noah Simon and Jerome Friedman and Trevor Hastie and Rob Tibshirani}, journal = {Journal of Statistical Software}, year = {2011}, volume = {39}, number = {5}, pages = {1--13}, url = {http://www.jstatsoft.org/v39/i05/}, }
 
-@misc{park_hastie, title={Package glmpath}, url={https://CRAN.R-project.org/package=glmpath}, journal={CRAN}, author={Park, Mee Young and Hastie, Trevor}, year={2018}, month={Jan}}
+
+
+@Manual{park_hastie,
+  title = {glmpath: L1 Regularization Path for Generalized Linear Models and Cox
+Proportional Hazards Model},
+  author = {Mee Young Park and Trevor Hastie},
+  year = {2018},
+  note = {R package version 0.98},
+  url = {https://CRAN.R-project.org/package=glmpath},
+}
+
+
+
 
 @Article{l1penal, title = {L1 penalized estimation in the Cox proportional hazards model}, author = {J. J. Goeman}, journal = {Biometrical Journal}, number = {52}, issue = {1}, pages = {-14}, year = {2010}, }
 
-@misc{gerds_blanche, title={Risk Regression Models and Prediction Scores for Survival Analysis with Competing Risks [R package riskRegression version 2019.11.03]}, url={https://CRAN.R-project.org/package=riskRegression}, journal={The Comprehensive R Archive Network}, publisher={Comprehensive R Archive Network (CRAN)}, author={Gerds, Thomas Alexander and Blanche, Paul and Mortersen, Rikke and Tollenaar, Nikolaj and Mogensen, Ulla Brasch and Ozenne, Brice}, year={2019}, month={Nov}}
 
-@misc{clements_liu, title={Smooth Survival Models, Including Generalized Survival Models [R package rstpm2 version 1.5.1]}, url={https://cran.r-project.org/web/packages/rstpm2/index.html}, journal={The Comprehensive R Archive Network}, publisher={Comprehensive R Archive Network (CRAN)}, author={Clements, Marc and Liu, Xing-Rong and Lambert, Paul and Jakobsen, Lasse Hajort and Gasparini, Alessandro and Smyth, Gordon and Alken, Patrick and Wood, Simon and Ulerich, Rhys}, year={2019}, month={Nov}}
+@Manual{gerds_blanche,
+  title = {riskRegression: Risk Regression Models and Prediction Scores for Survival
+Analysis with Competing Risks},
+  author = {Thomas Alexander Gerds and Brice Ozenne},
+  year = {2020},
+  note = {R package version 2020.02.05},
+  url = {https://CRAN.R-project.org/package=riskRegression},
+}
+
+
+
+
+@Manual{clements_liu,
+  title = {rstpm2: Smooth Survival Models, Including Generalized Survival Models},
+  author = {Mark Clements and Xing-Rong Liu},
+  year = {2019},
+  note = {R package version 1.5.1},
+  url = {https://CRAN.R-project.org/package=rstpm2},
+}
 
 @Article{smoothHazard, title = {{SmoothHazard}: An {R} Package for Fitting Regression Models to Interval-Censored Observations of Illness-Death Models}, author = {C\'elia Touraine and Thomas A. Gerds and Pierre Joly}, journal = {Journal of Statistical Software}, year = {2017}, volume = {79}, number = {7}, pages = {1--22}, doi = {10.18637/jss.v079.i07}, }
 
@@ -368,9 +412,20 @@
   publisher={Wiley Online Library}
 }
 
-@misc{goeman_meijer2019, title={Package penalized}, url={https://cran.r-project.org/web/packages/penalized/index.html}, journal={CRAN}, author={Goeman, Jelle and Meijer, Rosa and Chaturvedi, Nimisha and Lueder, Matthew}, year={2019}, month={Oct}}
+@Manual{goeman_meijer2019,
+  title = {Penalized: L1 (lasso and fused lasso) and L2 (ridge) penalized estimation in GLMs and in the Cox model},
+  author = {J. J. Goeman and R. J. Meijer and N. Chaturvedi},
+  year = {2018},
+  note = {R package version 0.9-51},
+}
 
-@misc{gray_2019, title={Package cmprsk}, url={https://cran.r-project.org/web/packages/cmprsk/index.html}, journal={Cran.r-project.org}, author={Gray, Bob}, year={2019}}
+@Manual{gray_2019,
+  title = {cmprsk: Subdistribution Analysis of Competing Risks},
+  author = {Bob Gray},
+  year = {2020},
+  note = {R package version 2.2-10},
+  url = {https://CRAN.R-project.org/package=cmprsk},
+}
 
 @misc{harrell_2020, title={SupportDesc < Main < Vanderbilt Biostatistics Wiki}, url={http://biostat.mc.vanderbilt.edu/wiki/Main/SupportDesc}, journal={Biostat.mc.vanderbilt.edu}, author={Harrell, Frank}, year={2020}}
 


### PR DESCRIPTION
*** did not fix the reference for coxRidge... its no longer on cran, I'm not sure what the best course of action is here.

All references that were labeled as misc (relating to packages other than coxridge) were updated with the citation function in R)

I did it off your branch, since I think its the most updated one? so I'd like to pull-request to the specific branch I updated on.